### PR TITLE
Execute NixOS tests in the CI

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -3,10 +3,12 @@ on: [ merge_group, push, pull_request ]
 jobs:
   flake-check:
     name: Nix Flake Checks
-    runs-on: ubuntu-latest
+    runs-on: large_runner_16core_64gb
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v30
       - uses: DeterminateSystems/flakehub-cache-action@main
       - name: Nix Flake Checks
         run: nix flake check --all-systems
+      - name: NixOS tests
+        run: nix build .#tests.x86_64-linux.openstack-default-setup.driver && ./result/bin/nixos-test-driver


### PR DESCRIPTION
Fortunately, we have access to the large github hosted runners, which have sufficient resources to run our NixOS tests.

This PR introduces the necessary changes to utilize these runners.

TODO:
* As runners are paid by time, we restrict the CI to run on PRs