### PR TITLE
fix: exclude failing test

### DIFF
--- a/packages/oslo-concurrency.nix
+++ b/packages/oslo-concurrency.nix
@@ -52,7 +52,7 @@ python3Packages.buildPythonPackage rec {
   ];
 
   checkPhase = ''
-    stestr run --exclude-regex ".*lock_with.*"
+    stestr run --exclude-regex ".*lock_with.*|test_core_size"
   '';
 
   src = fetchPypi {


### PR DESCRIPTION
Test with name `test_core_size` is failing from repo `openstack/oslo.concurrency` due to lack of permission of setting `RLIMIT_CORE` in nixbuild