### PR TITLE
fix: propagatedBuildInputs nova derivation

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -5,15 +5,15 @@ jobs:
     name: Nix Flake Checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
       - name: Nix Flake Checks
         run: nix flake check --all-systems
   nixos-tests:
     runs-on: large_runner_16core_64gb
     steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
       - name: Basic setup
         run: |
           nix build .#tests.x86_64-linux.openstack-default-setup.driver

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -16,9 +16,9 @@ jobs:
       - uses: cachix/install-nix-action@v31
       - name: Basic setup
         run: |
-          nix build .#tests.x86_64-linux.openstack-default-setup.driver
+          nix build -Lv .#tests.x86_64-linux.openstack-default-setup.driver
           ./result/bin/nixos-test-driver
       - name: Live migration
         run: |
-          nix build .#tests.x86_64-linux.openstack-live-migration.driver
+          nix build -Lv .#tests.x86_64-linux.openstack-live-migration.driver
           ./result/bin/nixos-test-driver

--- a/packages/nova.nix
+++ b/packages/nova.nix
@@ -77,6 +77,7 @@ let
     pyyaml
     requests
     requests-mock
+    requests-unixsocket
     retrying
     rfc3986
     routes
@@ -165,6 +166,7 @@ python3Packages.buildPythonPackage (rec {
     python-neutronclient
     pyyaml
     requests
+    requests-unixsocket
     retrying
     rfc3986
     routes


### PR DESCRIPTION
add python dependency: requests-unixsocket

follow up PR of: https://github.com/sapcc/nova/pull/613


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added the Python package dependency requests-unixsocket to nova’s build and runtime inputs.
* **Tests**
  * QA workflow updated to run NixOS test builds with an additional diagnostic/verbose build flag for test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->