### PR TITLE
add option to disable ssh port forwarding

### DIFF
--- a/modules/testing/README.md
+++ b/modules/testing/README.md
@@ -103,3 +103,42 @@ drwxr-xr-x 2 cinder cinder 4.0K Feb 24 08:16 .
 drwxr-xr-x 6 cinder cinder 4.0K Feb 24 08:09 ..
 -rw------- 1 cinder cinder  268 Feb 24 08:16 volume-64159e0c-18bb-449f-b1e0-86f198b170e4
 ```
+
+## Port Forwarding
+
+* Port forwarding is enabled by default for `controllerVM` and `storageVM` and disabled for `computeVM`.
+* If multiple computeVMs are used, a separate port must be assigned to each node; otherwise, collisions will occur.
+
+### Default ssh port forwards
+
+* controllerVM: `2022`
+* storageVM: `2122`
+* computeVM: `n/a`
+
+### Change default ports
+
+```nix
+
+pkgs.nixosTest {
+
+  nodes.controllerVM =
+    { ... }:
+    {
+      openstack-testing.sshHostPort = 2044; # default was: 2022
+    };
+
+  nodes.computeVM =
+    { ... }:
+    {
+      openstack-testing.enable = true; # enable / disable all port forwardings
+      openstack-testing.sshHostPort = 3022;
+    };
+
+  nodes.computeVM2 =
+    { ... }:
+    {
+      openstack-testing.enable = true; # enable / disable all port forwardings
+      openstack-testing.sshHostPort = 3122;
+    };
+}
+```

--- a/modules/testing/default.nix
+++ b/modules/testing/default.nix
@@ -54,7 +54,68 @@ let
       };
     };
 
-  portForwarding =
+  portForwardingStorage =
+    { config, lib, ... }:
+    with lib;
+    let
+      cfg = config.openstack-testing;
+    in
+    {
+      options.openstack-testing = {
+        enable = mkEnableOption "Enable port forwarding." // {
+          default = true;
+        };
+        sshHostPort = mkOption {
+          default = 2122;
+          type = types.port;
+          description = ''
+            Host port to make the ssh server available.
+          '';
+        };
+      };
+      config = mkIf cfg.enable {
+        virtualisation.forwardPorts = [
+          {
+            from = "host";
+            host.port = cfg.sshHostPort;
+            guest.port = 22;
+          }
+        ];
+      };
+    };
+
+  portForwardingCompute =
+    { config, lib, ... }:
+    with lib;
+    let
+      cfg = config.openstack-testing;
+    in
+    {
+      options.openstack-testing = {
+        enable = mkEnableOption "Enable port forwarding." // {
+          # If multiple nodes are used, a separate port must be assigned to each node; otherwise, collisions will occur.
+          # We disable ssh port forwarding for compute nodes as default.
+          default = false;
+        };
+        sshHostPort = mkOption {
+          type = types.port;
+          description = ''
+            Host port to make the ssh server available.
+          '';
+        };
+      };
+      config = mkIf cfg.enable {
+        virtualisation.forwardPorts = [
+          {
+            from = "host";
+            host.port = cfg.sshHostPort;
+            guest.port = 22;
+          }
+        ];
+      };
+    };
+
+  portForwardingController =
     { config, lib, ... }:
     with lib;
     let
@@ -92,6 +153,13 @@ let
             the configuration of the dashboard.
           '';
         };
+        sshHostPort = mkOption {
+          default = 2022;
+          type = types.port;
+          description = ''
+            Host port to make the ssh server available.
+          '';
+        };
       };
       config = mkIf cfg.enable {
         virtualisation.forwardPorts = [
@@ -109,6 +177,11 @@ let
             from = "host";
             host.port = cfg.vncProxyHostPort;
             guest.port = 6080;
+          }
+          {
+            from = "host";
+            host.port = cfg.sshHostPort;
+            guest.port = 22;
           }
         ];
       };
@@ -129,8 +202,12 @@ in
     {
       imports = [
         common
-        portForwarding
+        portForwardingController
       ];
+
+      # this is an example how to  enable / disable all port forwardings or change port numbers
+      # openstack-testing.enable = true;
+      # openstack-testing.sshHostPort = 1122;
 
       virtualisation = {
         cores = 4;
@@ -144,14 +221,6 @@ in
             vlan = 2;
           };
         };
-        # enable ssh access
-        forwardPorts = [
-          {
-            from = "host";
-            host.port = 1122;
-            guest.port = 22;
-          }
-        ];
       };
 
       systemd.services.openstack-create-vm = {
@@ -232,7 +301,14 @@ in
   testCompute =
     { ... }:
     {
-      imports = [ common ];
+      imports = [
+        common
+        portForwardingCompute
+      ];
+
+      # this is an example how to  enable / disable all port forwardings or change port numbers
+      # openstack-testing.enable = true; # enable / disable all port forwardings
+      # openstack-testing.sshHostPort = 3022;
 
       virtualisation = {
         memorySize = 4096;
@@ -271,14 +347,20 @@ in
           };
         };
       };
-
     };
 
   testStorage =
     { ... }:
     {
 
-      imports = [ common ];
+      imports = [
+        common
+        portForwardingStorage
+      ];
+
+      # this is an example how to  enable / disable all port forwardings or change port numbers
+      # openstack-testing.enable = true; # enable / disable all port forwardings
+      # openstack-testing.sshHostPort = 2022;
 
       virtualisation = {
         memorySize = 4096;
@@ -296,14 +378,6 @@ in
             vlan = 2;
           };
         };
-        # enable ssh access
-        forwardPorts = [
-          {
-            from = "host";
-            host.port = 2022;
-            guest.port = 22;
-          }
-        ];
       };
 
       systemd.network = {

--- a/tests/openstack-live-migration.nix
+++ b/tests/openstack-live-migration.nix
@@ -133,6 +133,9 @@ pkgs.nixosTest {
         (novaConfigForIp "10.0.0.39")
       ];
 
+      openstack-testing.enable = true; # enable / disable all port forwardings
+      openstack-testing.sshHostPort = 3022;
+
       networking.extraHosts = ''
         10.0.0.40 computeVM2 computeVM2.local
       '';
@@ -155,6 +158,9 @@ pkgs.nixosTest {
         nixosModules.testModules.testCompute
         (novaConfigForIp "10.0.0.40")
       ];
+
+      openstack-testing.enable = true; # enable / disable all port forwardings
+      openstack-testing.sshHostPort = 3122;
 
       networking.extraHosts = ''
         10.0.0.39 computeVM computeVM.local


### PR DESCRIPTION
In out CI we need an option to disable all
port forwardings to avoid port collisions
in parallel pipeline runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modularized SSH port-forwarding for test VMs, replacing inline forwarding with reusable submodules and per-role defaults.
* **New Features**
  * Per-node configurable SSH host ports for controller, storage and compute roles; storage forwarding enabled by default, compute disabled by default.
  * Live-migration test updated to enable per-compute SSH ports (examples use 3022 and 3122).
* **Documentation**
  * Added “Port Forwarding” section with examples to change ports and enable/disable forwarding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cobaltcore-dev/openstack-nix/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->