### PR TITLE
Configure Cinder to require admin service tokens

### DIFF
--- a/modules/controller/cinder.nix
+++ b/modules/controller/cinder.nix
@@ -31,6 +31,8 @@ let
     project_name = service
     username = cinder
     password = cinder
+    service_token_roles_required = true
+    service_token_roles = admin
 
     [oslo_concurrency]
     lock_path = /var/lib/cinder/tmp

--- a/modules/storage/cinder-storage-node.nix
+++ b/modules/storage/cinder-storage-node.nix
@@ -62,6 +62,8 @@ let
     project_name = service
     username = cinder
     password = cinder
+    service_token_roles_required = true
+    service_token_roles = admin
 
     [oslo_concurrency]
     lock_path = /var/lib/cinder/tmp
@@ -104,6 +106,8 @@ let
     project_name = service
     username = cinder
     password = cinder
+    service_token_roles_required = true
+    service_token_roles = admin
 
     [oslo_concurrency]
     lock_path = /var/lib/cinder/tmp


### PR DESCRIPTION
Configure Cinder to require admin token for certain actions. 

Required for some actions Nova wants to do at Cinder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Enhanced Keystone service token validation requirements for the Cinder block storage API.
  * Updated authentication configuration for NFS storage backends to include additional role-based access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->