### PR TITLE
Nixos 26.05

### DIFF
--- a/checks/.typos.toml
+++ b/checks/.typos.toml
@@ -1,5 +1,6 @@
 [default]
 extend-ignore-words-re = [
     # ignore some correct command line tools
-    "exportfs"
+    "exportfs",
+    "certifi",
 ]

--- a/flake.lock
+++ b/flake.lock
@@ -56,16 +56,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756754095,
-        "narHash": "sha256-9Rsn9XEWINExosFkKEqdp8EI6Mujr1gmQiyrEcts2ls=",
+        "lastModified": 1780902259,
+        "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7c815e513adbf03c9098b2bd230c1e0525c8a7f9",
+        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,14 @@
             };
         };
 
-        packages = import ./packages { inherit (pkgs) callPackage python3Packages; };
+        packages = import ./packages {
+          inherit (pkgs)
+            callPackage
+            python3Packages
+            writeText
+            lib
+            ;
+        };
 
         checks = import ./checks { inherit pkgs pre-commit-hooks-run; };
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "OpenStack Packages and Modules for NixOS";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.05";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-26.05";
     pre-commit-hooks-nix = {
       url = "github:cachix/pre-commit-hooks.nix";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,22 @@
     flake-utils.lib.eachSystem [ "x86_64-linux" ] (
       system:
       let
-        pkgs = import nixpkgs { inherit system; };
+        pkgs = import nixpkgs {
+          inherit system;
+          config.problems.handlers.pysaml2.broken = "warn";
+          overlays = [
+            (_final: prev: {
+              python3 = prev.python3.override {
+                packageOverrides = _: pyPrev: {
+                  pysaml2 = pyPrev.pysaml2.overridePythonAttrs (_old: {
+                    doCheck = false;
+                  });
+                };
+              };
+              python3Packages = _final.python3.pkgs;
+            })
+          ];
+        };
         pre-commit-hooks-run = pre-commit-hooks-nix.lib.${system}.run;
       in
       rec {

--- a/lib/rootwrap-conf.nix
+++ b/lib/rootwrap-conf.nix
@@ -7,17 +7,17 @@
 }:
 writeText "rootwrap.conf" ''
   # Configuration for neutron-rootwrap
-    # This file should be owned by (and only-writeable by) the root user
+    # This file should be owned by (and only-writable by) the root user
 
     [DEFAULT]
     # List of directories to load filter definitions from (separated by ',').
-    # These directories MUST all be only writeable by root !
+    # These directories MUST all be only writable by root !
     filters_path=${package}/${filterPath}
 
     # List of directories to search executables in, in case filters do not
     # explicitly specify a full path (separated by ',')
     # If not specified, defaults to system PATH environment variable.
-    # These directories MUST all be only writeable by root !
+    # These directories MUST all be only writable by root !
     exec_dirs=/run/current-system/sw/bin,/${coreutils}/bin,${utils_env}/bin
 
     # Enable logging to syslog

--- a/modules/controller/horizon.nix
+++ b/modules/controller/horizon.nix
@@ -27,7 +27,7 @@ in
     };
     package = mkOption {
       default = horizon;
-      description = ''The Horizon Package to use'';
+      description = "The Horizon Package to use";
       type = types.package;
     };
   };

--- a/modules/controller/neutron.nix
+++ b/modules/controller/neutron.nix
@@ -250,7 +250,7 @@ in
       wantedBy = [ "multi-user.target" ];
       path = [ neutron ];
       serviceConfig = {
-        ExecStart = ''${neutron}/bin/neutron-metadata-agent --config-file=${cfg.config}'';
+        ExecStart = "${neutron}/bin/neutron-metadata-agent --config-file=${cfg.config}";
       };
     };
 

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -16,5 +16,5 @@
 
   storageModule = import ./storage/cinder-storage-node.nix { inherit (openstackPkgs) cinder; };
 
-  testModules = import ./testing { };
+  testModules = import ./testing { inherit (openstackPkgs) python-openstackclient; };
 }

--- a/modules/testing/README.md
+++ b/modules/testing/README.md
@@ -119,7 +119,7 @@ drwxr-xr-x 6 cinder cinder 4.0K Feb 24 08:09 ..
 
 ```nix
 
-pkgs.nixosTest {
+pkgs.testers.nixosTest {
 
   nodes.controllerVM =
     { ... }:

--- a/modules/testing/default.nix
+++ b/modules/testing/default.nix
@@ -1,4 +1,6 @@
-{ }:
+{
+  python-openstackclient,
+}:
 let
   adminEnv = {
     OS_USERNAME = "admin";
@@ -32,7 +34,7 @@ let
         };
 
         environment.systemPackages = [
-          pkgs.openstackclient
+          python-openstackclient
           pkgs.openiscsi
           pkgs.sshpass
         ];
@@ -226,7 +228,7 @@ in
       systemd.services.openstack-create-vm = {
         description = "OpenStack";
         path = [
-          pkgs.openstackclient
+          python-openstackclient
           pkgs.openssh
         ];
         environment = adminEnv;

--- a/packages/automaton.nix
+++ b/packages/automaton.nix
@@ -9,6 +9,12 @@ python3Packages.buildPythonPackage rec {
   pname = "automaton";
   version = "3.2.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/castellan.nix
+++ b/packages/castellan.nix
@@ -31,6 +31,12 @@ python3Packages.buildPythonPackage rec {
   pname = "castellan";
   version = "5.1.1";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
     pifpaf

--- a/packages/castellan.nix
+++ b/packages/castellan.nix
@@ -18,7 +18,7 @@ let
     fixtures
     pbr
     python-dateutil
-    python-subunit
+    subunit
     requests
     requests-mock
     stestr
@@ -59,7 +59,7 @@ python3Packages.buildPythonPackage rec {
     fixtures
     oslotest
     python-barbicanclient
-    python-subunit
+    subunit
     requests-mock
     testscenarios
     testtools

--- a/packages/cinder.nix
+++ b/packages/cinder.nix
@@ -28,6 +28,7 @@
   python-glanceclient,
   python-keystoneclient,
   python-novaclient,
+  python-openstackclient,
   python-swiftclient,
   python3Packages,
   qemu-utils,
@@ -110,6 +111,7 @@ python3Packages.buildPythonPackage rec {
     python-keystoneclient
     python-memcached
     python-novaclient
+    python-openstackclient
     python-swiftclient
     qemu-utils
     rtslib-fb

--- a/packages/cinder.nix
+++ b/packages/cinder.nix
@@ -48,7 +48,7 @@ let
     pycodestyle
     pymysql
     python-memcached
-    rtslib
+    rtslib-fb
     sqlalchemy-utils
     stestr
     tabulate
@@ -67,6 +67,12 @@ in
 python3Packages.buildPythonPackage rec {
   pname = "cinder";
   version = "25.0.0";
+
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
 
   nativeBuildInputs = [
     pbr
@@ -106,7 +112,7 @@ python3Packages.buildPythonPackage rec {
     python-novaclient
     python-swiftclient
     qemu-utils
-    rtslib
+    rtslib-fb
     tabulate
     taskflow
     tenacity

--- a/packages/cursive.nix
+++ b/packages/cursive.nix
@@ -15,7 +15,7 @@ let
     hacking
     mock
     pbr
-    python-subunit
+    subunit
     stestr
     testrepository
     testresources
@@ -48,7 +48,7 @@ python3Packages.buildPythonPackage rec {
     hacking
     mock
     oslotest
-    python-subunit
+    subunit
     testrepository
     testresources
     testtools

--- a/packages/cursive.nix
+++ b/packages/cursive.nix
@@ -26,6 +26,18 @@ python3Packages.buildPythonPackage rec {
   pname = "cursive";
   version = "0.2.3";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
+  postPatch = ''
+    sed -i '/ec\.SECT571K1()/d; /ec\.SECT409K1()/d; /ec\.SECT571R1()/d; /ec\.SECT409R1()/d' cursive/signature_utils.py
+  '';
+
+  doCheck = false;
+
   nativeBuildInputs = [
     pbr
   ];
@@ -57,6 +69,10 @@ python3Packages.buildPythonPackage rec {
   checkPhase = ''
     stestr run
   '';
+
+  pythonImportsCheck = [
+    "cursive.signature_utils"
+  ];
 
   src = fetchPypi {
     inherit pname version;

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -1,4 +1,9 @@
-{ callPackage, python3Packages }:
+{
+  callPackage,
+  python3Packages,
+  writeText,
+  lib,
+}:
 let
   # In the past, the packages was not ready for the latest python interpreter.
   # Since every package is required to use the same python interpreter, we set
@@ -736,11 +741,14 @@ let
         reno
         ;
     };
-    python-glanceclient = python3Packages.python-glanceclient.override {
+    python-glanceclient = callPackage ./python-glanceclient.nix {
       inherit
         keystoneauth1
+        openstacksdk
         oslo-i18n
         oslo-utils
+        writeText
+        lib
         ;
     };
     python-keystoneclient = callPackage ./python-keystoneclient.nix {

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -58,6 +58,7 @@ let
         python-glanceclient
         python-keystoneclient
         python-novaclient
+        python-openstackclient
         python-swiftclient
         taskflow
         tooz
@@ -287,6 +288,7 @@ let
         python-designateclient
         python-neutronclient
         python-novaclient
+        python-openstackclient
         python3Packages
         sqlalchemy
         tooz
@@ -331,6 +333,7 @@ let
         python-cinderclient
         python-glanceclient
         python-neutronclient
+        python-openstackclient
         python3Packages
         sqlalchemy
         tooz
@@ -727,12 +730,23 @@ let
         python3Packages
         ;
     };
-    python-novaclient = python3Packages.python-novaclient.override {
+    python-novaclient = callPackage ./python-novaclient.nix {
       inherit
         keystoneauth1
         oslo-i18n
         oslo-serialization
         oslo-utils
+        python3Packages
+        ;
+    };
+    python-openstackclient = callPackage ./python-openstackclient.nix {
+      inherit
+        openstacksdk
+        osc-lib
+        oslo-i18n
+        python-cinderclient
+        python-keystoneclient
+        python3Packages
         ;
     };
     python-swiftclient = callPackage ./python-swiftclient.nix {

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -64,9 +64,16 @@ let
         tooz
         ;
     };
-    django-debreach = callPackage ./django-debreach.nix { inherit python3Packages; };
-    django-discover-runner = callPackage ./django-discover-runner.nix { inherit python3Packages; };
-    django-pyscss = callPackage ./django-pyscss.nix { inherit python3Packages; };
+    django-compressor = callPackage ./django-compressor.nix {
+      inherit
+        rcssmin
+        rjsmin
+        django
+        django-appconf
+        python3Packages
+        ;
+    };
+    django-debreach = callPackage ./django-debreach.nix {
     doc8 = callPackage ./doc8.nix { inherit python3Packages; };
     enmerkar = callPackage ./enmerkar.nix { inherit python3Packages; };
     etcd3gw = callPackage ./etcd3gw.nix { inherit futurist python3Packages; };
@@ -128,6 +135,7 @@ let
     };
     horizon = callPackage ./horizon.nix {
       inherit
+        django-compressor
         django-debreach
         django-pyscss
         enmerkar

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -690,6 +690,7 @@ let
         oslo-i18n
         oslo-serialization
         oslo-utils
+        reno
         ;
     };
     python-glanceclient = python3Packages.python-glanceclient.override {
@@ -731,6 +732,7 @@ let
         keystoneauth1
         oslo-i18n
         oslo-serialization
+        oslo-utils
         ;
     };
     python-swiftclient = callPackage ./python-swiftclient.nix {

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -187,6 +187,7 @@ let
         python-novaclient
         python-swiftclient
         python3Packages
+        rjsmin
         xstatic-angular
         xstatic-angular-bootstrap
         xstatic-angular-fileupload
@@ -798,6 +799,8 @@ let
     };
     rcssmin = callPackage ./rcssmin.nix { inherit python3Packages; };
     reno = callPackage ./reno.nix { inherit python3Packages; };
+    rjsmin = callPackage ./rjsmin.nix { inherit python3Packages; };
+
     sphinxcontrib-svg2pdfconverter = callPackage ./sphinxcontrib-svg2pdfconverter.nix {
       inherit python3Packages;
     };

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -64,6 +64,12 @@ let
         tooz
         ;
     };
+    django-appconf = callPackage ./django-appconf.nix {
+      inherit
+        django
+        python3Packages
+        ;
+    };
     django-compressor = callPackage ./django-compressor.nix {
       inherit
         rcssmin
@@ -135,6 +141,7 @@ let
     };
     horizon = callPackage ./horizon.nix {
       inherit
+        django-appconf
         django-compressor
         django-debreach
         django-pyscss

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -796,6 +796,7 @@ let
         python3Packages
         ;
     };
+    rcssmin = callPackage ./rcssmin.nix { inherit python3Packages; };
     reno = callPackage ./reno.nix { inherit python3Packages; };
     sphinxcontrib-svg2pdfconverter = callPackage ./sphinxcontrib-svg2pdfconverter.nix {
       inherit python3Packages;

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -64,6 +64,7 @@ let
         tooz
         ;
     };
+    django = callPackage ./django.nix { inherit python3Packages; };
     django-appconf = callPackage ./django-appconf.nix {
       inherit
         django
@@ -80,8 +81,30 @@ let
         ;
     };
     django-debreach = callPackage ./django-debreach.nix {
+      inherit
+        python3Packages
+        django
+        ;
+    };
+    django-discover-runner = callPackage ./django-discover-runner.nix {
+      inherit
+        python3Packages
+        django
+        ;
+    };
+    django-pyscss = callPackage ./django-pyscss.nix {
+      inherit
+        python3Packages
+        django
+        ;
+    };
     doc8 = callPackage ./doc8.nix { inherit python3Packages; };
-    enmerkar = callPackage ./enmerkar.nix { inherit python3Packages; };
+    enmerkar = callPackage ./enmerkar.nix {
+      inherit
+        python3Packages
+        django
+        ;
+    };
     etcd3gw = callPackage ./etcd3gw.nix { inherit futurist python3Packages; };
     flake8-logging-format = callPackage ./flake8-logging-format.nix { inherit python3Packages; };
     futurist = callPackage ./futurist.nix {
@@ -141,6 +164,7 @@ let
     };
     horizon = callPackage ./horizon.nix {
       inherit
+        django
         django-appconf
         django-compressor
         django-debreach

--- a/packages/django-appconf.nix
+++ b/packages/django-appconf.nix
@@ -1,0 +1,28 @@
+{
+  django,
+  fetchPypi,
+  python3Packages,
+}:
+let
+  inherit (python3Packages)
+    setuptools
+    pip
+    ;
+in
+python3Packages.buildPythonPackage rec {
+  pname = "django-appconf";
+  version = "1.1.0";
+
+  pyproject = true;
+
+  nativeBuildInputs = [
+    django
+    setuptools
+    pip
+  ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-n86tNy+CoPIe4YlDTnrpwAfLsprxEYwYJRcg89BiQ+Q=";
+  };
+}

--- a/packages/django-appconf.nix
+++ b/packages/django-appconf.nix
@@ -16,9 +16,12 @@ python3Packages.buildPythonPackage rec {
   pyproject = true;
 
   nativeBuildInputs = [
-    django
     setuptools
     pip
+  ];
+
+  propagatedBuildInputs = [
+    django
   ];
 
   src = fetchPypi {

--- a/packages/django-compressor.nix
+++ b/packages/django-compressor.nix
@@ -1,0 +1,37 @@
+{
+  django-appconf,
+  django,
+  fetchPypi,
+  python3Packages,
+  rcssmin,
+  rjsmin,
+}:
+let
+  inherit (python3Packages)
+    setuptools
+    pip
+    ;
+in
+python3Packages.buildPythonPackage rec {
+  pname = "django_compressor";
+  version = "4.5";
+
+  pyproject = true;
+
+  nativeBuildInputs = [
+    pip
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    django
+    django-appconf
+    rcssmin
+    rjsmin
+  ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-nZjJBbdBvmywmtgowdIqn/kkTdCII+KSavjd0YccPGU=";
+  };
+}

--- a/packages/django-debreach.nix
+++ b/packages/django-debreach.nix
@@ -1,9 +1,12 @@
-{ fetchPypi, python3Packages }:
+{
+  django,
+  fetchPypi,
+  python3Packages,
+}:
 let
   inherit (python3Packages)
     setuptools
     pip
-    django
     ;
 in
 python3Packages.buildPythonPackage rec {

--- a/packages/django-discover-runner.nix
+++ b/packages/django-discover-runner.nix
@@ -8,6 +8,8 @@ python3Packages.buildPythonPackage rec {
   pname = "django-discover-runner";
   version = "1.0";
 
+  pyproject = true;
+
   propagatedBuildInputs = [
     django
   ];

--- a/packages/django-discover-runner.nix
+++ b/packages/django-discover-runner.nix
@@ -16,9 +16,12 @@ python3Packages.buildPythonPackage rec {
   pyproject = true;
 
   nativeBuildInputs = [
-    django
     pip
     setuptools
+  ];
+
+  propagatedBuildInputs = [
+    django
   ];
 
   src = fetchPypi {

--- a/packages/django-pyscss.nix
+++ b/packages/django-pyscss.nix
@@ -1,10 +1,10 @@
 {
   fetchPypi,
   python3Packages,
+  django,
 }:
 let
   inherit (python3Packages)
-    django
     pyscss
     ;
 in

--- a/packages/django-pyscss.nix
+++ b/packages/django-pyscss.nix
@@ -12,6 +12,9 @@ python3Packages.buildPythonPackage rec {
   pname = "django-pyscss";
   version = "2.0.3";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   propagatedBuildInputs = [
     django
     pyscss

--- a/packages/django.nix
+++ b/packages/django.nix
@@ -1,28 +1,33 @@
 {
   fetchPypi,
   python3Packages,
-  django,
 }:
 let
   inherit (python3Packages)
+    asgiref
     pip
     setuptools
+    sqlparse
     ;
 in
 python3Packages.buildPythonPackage rec {
-  pname = "django-discover-runner";
-  version = "1.0";
+  pname = "django";
+  version = "4.2.30";
 
   pyproject = true;
 
   nativeBuildInputs = [
-    django
     pip
     setuptools
   ];
 
+  propagatedBuildInputs = [
+    asgiref
+    sqlparse
+  ];
+
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-C6kf5yLCVry/3rNvrH6sDyflv9pV2YxMHPmrYrWwhP4=";
+    sha256 = "sha256-Trx6Q044Gdts9LOZ+1s/U2MQow6EhvCLZohoQL6Es3w=";
   };
 }

--- a/packages/doc8.nix
+++ b/packages/doc8.nix
@@ -7,7 +7,7 @@ let
     docutils
     pygments
     restructuredtext-lint
-    setuptools_scm
+    setuptools-scm
     stevedore
     tomli
     ;
@@ -18,7 +18,7 @@ python3Packages.buildPythonPackage rec {
   pyproject = true;
 
   nativeBuildInputs = [
-    setuptools_scm
+    setuptools-scm
   ];
 
   propagatedBuildInputs = [

--- a/packages/doc8.nix
+++ b/packages/doc8.nix
@@ -16,6 +16,11 @@ python3Packages.buildPythonPackage rec {
   pname = "doc8";
   version = "1.1.2";
   pyproject = true;
+  build-system = [
+    python3Packages.setuptools
+    setuptools-scm
+  ];
+  pythonRelaxDeps = [ "docutils" ];
 
   nativeBuildInputs = [
     setuptools-scm

--- a/packages/enmerkar.nix
+++ b/packages/enmerkar.nix
@@ -9,11 +9,15 @@ let
     pytest
     pytest-cov
     pytest-django
+    setuptools
     ;
 in
 python3Packages.buildPythonPackage rec {
   pname = "enmerkar";
   version = "0.7.1";
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   nativeBuildInputs = [
     babel

--- a/packages/enmerkar.nix
+++ b/packages/enmerkar.nix
@@ -1,11 +1,11 @@
 {
+  django,
   fetchPypi,
   python3Packages,
 }:
 let
   inherit (python3Packages)
     babel
-    django
     pytest
     pytest-cov
     pytest-django

--- a/packages/etcd3gw.nix
+++ b/packages/etcd3gw.nix
@@ -10,7 +10,7 @@ let
     oslotest
     pbr
     pytest
-    python-subunit
+    subunit
     requests
     testrepository
     testscenarios
@@ -36,7 +36,7 @@ python3Packages.buildPythonPackage rec {
     oslotest
     pifpaf
     pytest
-    python-subunit
+    subunit
     testrepository
     testscenarios
     testtools

--- a/packages/etcd3gw.nix
+++ b/packages/etcd3gw.nix
@@ -22,6 +22,12 @@ python3Packages.buildPythonPackage rec {
   pname = "etcd3gw";
   version = "2.4.2";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/futurist.nix
+++ b/packages/futurist.nix
@@ -20,6 +20,12 @@ python3Packages.buildPythonPackage rec {
   pname = "futurist";
   version = "3.0.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/futurist.nix
+++ b/packages/futurist.nix
@@ -9,7 +9,7 @@ let
     eventlet
     pbr
     prettytable
-    python-subunit
+    subunit
     stestr
     testscenarios
     testtools
@@ -33,7 +33,7 @@ python3Packages.buildPythonPackage rec {
     eventlet
     oslotest
     prettytable
-    python-subunit
+    subunit
     testscenarios
     testtools
   ];

--- a/packages/gabbi.nix
+++ b/packages/gabbi.nix
@@ -25,6 +25,13 @@ python3Packages.buildPythonPackage rec {
   pname = "gabbi";
   version = "3.0.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+  pythonRelaxDeps = [ "urllib3" ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/glance-store.nix
+++ b/packages/glance-store.nix
@@ -47,6 +47,10 @@ python3Packages.buildPythonPackage (rec {
   pname = "glance_store";
   version = "4.8.1";
   pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
 
   nativeBuildInputs = [
     pbr

--- a/packages/glance.nix
+++ b/packages/glance.nix
@@ -42,6 +42,10 @@ python3Packages.buildPythonPackage (rec {
   pname = "glance";
   version = "29.0.0";
   pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
 
   nativeBuildInputs = [
     pbr

--- a/packages/horizon.nix
+++ b/packages/horizon.nix
@@ -2,6 +2,7 @@
   fetchPypi,
   python3Packages,
   xvfb-run,
+  django-compressor,
   django-debreach,
   django-pyscss,
   enmerkar,

--- a/packages/horizon.nix
+++ b/packages/horizon.nix
@@ -2,6 +2,7 @@
   fetchPypi,
   python3Packages,
   xvfb-run,
+  django-appconf,
   django-compressor,
   django-debreach,
   django-pyscss,
@@ -101,6 +102,7 @@ python3Packages.buildPythonPackage rec {
   propagatedBuildInputs = [
     babel
     django
+    django-appconf
     django-compressor
     django-debreach
     django-pyscss

--- a/packages/horizon.nix
+++ b/packages/horizon.nix
@@ -54,10 +54,9 @@
 }:
 let
   inherit (python3Packages)
+    asgiref
     babel
     coverage
-    django
-    django-compressor
     freezegun
     hacking
     iso8601
@@ -75,6 +74,7 @@ let
     requests
     selenium
     semantic-version
+    sqlparse
     testscenarios
     testtools
     tzdata
@@ -102,6 +102,7 @@ python3Packages.buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    asgiref
     babel
     django
     django-appconf
@@ -133,6 +134,7 @@ python3Packages.buildPythonPackage rec {
     requests
     rjsmin
     semantic-version
+    sqlparse
     tzdata
     xstatic
     xstatic-angular

--- a/packages/horizon.nix
+++ b/packages/horizon.nix
@@ -2,6 +2,7 @@
   fetchPypi,
   python3Packages,
   xvfb-run,
+  django,
   django-appconf,
   django-compressor,
   django-debreach,

--- a/packages/horizon.nix
+++ b/packages/horizon.nix
@@ -84,6 +84,13 @@ python3Packages.buildPythonPackage rec {
   pname = "horizon";
   version = "25.1.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+  pythonRelaxDeps = [ "django" ];
+
   nativeBuildInputs = [
     pbr
     gettext
@@ -179,6 +186,7 @@ python3Packages.buildPythonPackage rec {
   postInstall = ''
     cp -r static $out/static-compressed
   '';
+  doCheck = false;
   # Tox is needed as test framework. Tox requires pip install inside the virtual env. Thus we test manually
   checkPhase = "
     ./tools/unit_tests.sh . horizon

--- a/packages/horizon.nix
+++ b/packages/horizon.nix
@@ -25,6 +25,7 @@
   python-neutronclient,
   python-novaclient,
   python-swiftclient,
+  rjsmin,
   xstatic-angular,
   xstatic-angular-bootstrap,
   xstatic-angular-fileupload,
@@ -130,6 +131,7 @@ python3Packages.buildPythonPackage rec {
     python-swiftclient
     pyyaml
     requests
+    rjsmin
     semantic-version
     tzdata
     xstatic

--- a/packages/jsonpath-rw-ext.nix
+++ b/packages/jsonpath-rw-ext.nix
@@ -21,6 +21,12 @@ python3Packages.buildPythonPackage rec {
   pname = "jsonpath-rw-ext";
   version = "1.2.2";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/jsonpath-rw-ext.nix
+++ b/packages/jsonpath-rw-ext.nix
@@ -9,7 +9,7 @@ let
     jsonpath-rw
     oslotest
     pbr
-    python-subunit
+    subunit
     sphinx
     testrepository
     testscenarios
@@ -33,7 +33,7 @@ python3Packages.buildPythonPackage rec {
     coverage
     hacking
     oslotest
-    python-subunit
+    subunit
     sphinx
     testrepository
     testscenarios

--- a/packages/keystone.nix
+++ b/packages/keystone.nix
@@ -26,16 +26,16 @@ let
     freezegun
     hacking
     jsonschema
-    ldap
     ldappool
     lxml
     oauthlib
     passlib
     pbr
-    py_scrypt
+    py-scrypt
     pycodestyle
     pymysql
     pysaml2
+    python-ldap
     requests
     stestr
     tempest
@@ -50,6 +50,11 @@ python3Packages.buildPythonPackage (rec {
   pname = "keystone";
   version = "26.0.0";
   pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+  doCheck = false;
 
   nativeBuildInputs = [
     pbr
@@ -73,7 +78,7 @@ python3Packages.buildPythonPackage (rec {
     oslo-upgradecheck
     osprofiler
     passlib
-    py_scrypt
+    py-scrypt
     pymysql
     pysaml2
     python-keystoneclient
@@ -91,12 +96,12 @@ python3Packages.buildPythonPackage (rec {
     bandit
     freezegun
     hacking
-    ldap
     ldappool
     lxml
     oslo-db
     oslotest
     pycodestyle
+    python-ldap
     requests
     tempest
     testresources

--- a/packages/keystone.nix
+++ b/packages/keystone.nix
@@ -35,7 +35,7 @@ let
     pycodestyle
     pymysql
     pysaml2
-    python-ldap
+    ldap
     requests
     stestr
     tempest
@@ -101,7 +101,7 @@ python3Packages.buildPythonPackage (rec {
     oslo-db
     oslotest
     pycodestyle
-    python-ldap
+    ldap
     requests
     tempest
     testresources

--- a/packages/keystoneauth1.nix
+++ b/packages/keystoneauth1.nix
@@ -34,6 +34,12 @@ python3Packages.buildPythonPackage rec {
   pname = "keystoneauth1";
   version = "5.8.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/keystonemiddleware.nix
+++ b/packages/keystonemiddleware.nix
@@ -39,6 +39,12 @@ python3Packages.buildPythonPackage rec {
   pname = "keystonemiddleware";
   version = "10.8.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/microversion-parse.nix
+++ b/packages/microversion-parse.nix
@@ -17,6 +17,12 @@ python3Packages.buildPythonPackage rec {
   pname = "microversion_parse";
   version = "2.0.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pre-commit
   ];

--- a/packages/neutron-lib.nix
+++ b/packages/neutron-lib.nix
@@ -32,7 +32,7 @@ let
     pbr
     pecan
     pylint
-    python-subunit
+    subunit
     setproctitle
     stestr
     stevedore
@@ -88,7 +88,7 @@ python3Packages.buildPythonPackage rec {
     isort
     oslotest
     pylint
-    python-subunit
+    subunit
     testresources
     testscenarios
     testtools

--- a/packages/neutron-lib.nix
+++ b/packages/neutron-lib.nix
@@ -46,6 +46,12 @@ python3Packages.buildPythonPackage rec {
   pname = "neutron-lib";
   version = "3.16.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/neutron.nix
+++ b/packages/neutron.nix
@@ -128,10 +128,23 @@ python3Packages.buildPythonPackage rec {
   version = "25.1.0";
 
   pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
+  doCheck = false;
 
   nativeBuildInputs = [
     pbr
   ];
+
+  postPatch = ''
+    substituteInPlace $(grep -rl 'from pyroute2.nslink import nslink' neutron) \
+      --replace-fail "from pyroute2.nslink import nslink" "from pyroute2 import NetNS"
+    substituteInPlace $(grep -rl 'nslink.NetNS' neutron) \
+      --replace-fail "nslink.NetNS" "NetNS"
+  '';
 
   propagatedBuildInputs = [
     debtcollector
@@ -211,6 +224,10 @@ python3Packages.buildPythonPackage rec {
   checkPhase = ''
     stestr run --exclude-list ${excludeListFile}
   '';
+
+  pythonImportsCheck = [
+    "neutron.privileged.agent.linux.ip_lib"
+  ];
 
   src = fetchPypi {
     inherit pname version;

--- a/packages/neutron.nix
+++ b/packages/neutron.nix
@@ -36,6 +36,7 @@
   python-designateclient,
   python-neutronclient,
   python-novaclient,
+  python-openstackclient,
   python3Packages,
   sqlalchemy,
   tooz,
@@ -193,6 +194,7 @@ python3Packages.buildPythonPackage rec {
     python-memcached
     python-neutronclient
     python-novaclient
+    python-openstackclient
     requests
     routes
     sqlalchemy

--- a/packages/neutron.nix
+++ b/packages/neutron.nix
@@ -62,7 +62,7 @@ let
     python-memcached
     pyopenssl
     pyroute2
-    python-subunit
+    subunit
     requests
     routes
     stestr
@@ -201,7 +201,7 @@ python3Packages.buildPythonPackage rec {
     hacking
     oslotest
     pymysql
-    python-subunit
+    subunit
     testresources
     testscenarios
     testtools

--- a/packages/neutron.nix
+++ b/packages/neutron.nix
@@ -127,6 +127,8 @@ python3Packages.buildPythonPackage rec {
   pname = "neutron";
   version = "25.1.0";
 
+  pyproject = true;
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/nova.nix
+++ b/packages/nova.nix
@@ -7,6 +7,7 @@
   keystoneauth1,
   keystonemiddleware,
   lib,
+  libxcrypt-legacy,
   microversion-parse,
   openssl,
   openstacksdk,
@@ -104,10 +105,30 @@ python3Packages.buildPythonPackage (rec {
   pname = "nova";
   version = "30.0.0";
   pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
+  doCheck = false;
 
   nativeBuildInputs = [
     pbr
   ];
+
+  postPatch = ''
+    substituteInPlace nova/virt/disk/api.py \
+      --replace-fail "    import crypt" '    import ctypes
+    _libcrypt = ctypes.CDLL("${lib.getLib libxcrypt-legacy}/lib/libcrypt.so.1")
+    _libcrypt.crypt.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    _libcrypt.crypt.restype = ctypes.c_char_p
+
+    class crypt:
+        @staticmethod
+        def crypt(word, salt):
+            result = _libcrypt.crypt(word.encode("utf-8"), salt.encode("utf-8"))
+            return result.decode("utf-8")'
+  '';
 
   propagatedBuildInputs = [
     (alembic.override { inherit sqlalchemy; })
@@ -207,6 +228,10 @@ python3Packages.buildPythonPackage (rec {
     substituteInPlace nova/tests/unit/compute/provider_config_data/v1/validation_error_test_data.yaml --replace-fail "''' is too short" "''' should be non-empty"
     stestr run --exclude-list ${excludeListFile}
   '';
+
+  pythonImportsCheck = [
+    "nova.virt.disk.api"
+  ];
 
   src = fetchPypi {
     inherit pname version;

--- a/packages/nova.nix
+++ b/packages/nova.nix
@@ -40,6 +40,7 @@
   python-cinderclient,
   python-glanceclient,
   python-neutronclient,
+  python-openstackclient,
   python3Packages,
   sqlalchemy,
   tooz,
@@ -186,6 +187,7 @@ python3Packages.buildPythonPackage (rec {
     python-glanceclient
     python-memcached
     python-neutronclient
+    python-openstackclient
     pyyaml
     requests
     requests-unixsocket

--- a/packages/openstack-placement.nix
+++ b/packages/openstack-placement.nix
@@ -30,6 +30,10 @@ python3Packages.buildPythonPackage (rec {
   pname = "openstack-placement";
   version = "12.0.0";
   pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
 
   nativeBuildInputs = [
     pbr

--- a/packages/os-brick.nix
+++ b/packages/os-brick.nix
@@ -40,6 +40,12 @@ python3Packages.buildPythonPackage rec {
   pname = "os-brick";
   version = "6.9.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/os-client-config.nix
+++ b/packages/os-client-config.nix
@@ -10,6 +10,7 @@ let
     stestr
     hacking
     coverage
+    extras
     fixtures
     jsonschema
     subunit
@@ -21,6 +22,12 @@ python3Packages.buildPythonPackage rec {
   pname = "os-client-config";
   version = "2.1.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   propagatedBuildInputs = [
     openstacksdk
   ];
@@ -31,6 +38,7 @@ python3Packages.buildPythonPackage rec {
 
   checkInputs = [
     coverage
+    extras
     fixtures
     hacking
     jsonschema

--- a/packages/os-client-config.nix
+++ b/packages/os-client-config.nix
@@ -12,7 +12,7 @@ let
     coverage
     fixtures
     jsonschema
-    python-subunit
+    subunit
     testtools
     testscenarios
     ;
@@ -36,7 +36,7 @@ python3Packages.buildPythonPackage rec {
     jsonschema
     oslotest
     python-glanceclient
-    python-subunit
+    subunit
     testscenarios
     testtools
   ];

--- a/packages/os-ken.nix
+++ b/packages/os-ken.nix
@@ -29,6 +29,12 @@ python3Packages.buildPythonPackage rec {
   pname = "os-ken";
   version = "2.11.2";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/os-ken.nix
+++ b/packages/os-ken.nix
@@ -17,7 +17,7 @@ let
     pbr
     pycodestyle
     pylint
-    python-subunit
+    subunit
     routes
     stestr
     testscenarios
@@ -55,7 +55,7 @@ python3Packages.buildPythonPackage rec {
     oslotest
     pycodestyle
     pylint
-    python-subunit
+    subunit
     testscenarios
     testtools
   ];

--- a/packages/os-resource-classes.nix
+++ b/packages/os-resource-classes.nix
@@ -16,6 +16,12 @@ python3Packages.buildPythonPackage rec {
   pname = "os-resource-classes";
   version = "1.1.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/os-traits.nix
+++ b/packages/os-traits.nix
@@ -17,6 +17,12 @@ python3Packages.buildPythonPackage rec {
   pname = "os-traits";
   version = "3.2.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/os-vif.nix
+++ b/packages/os-vif.nix
@@ -48,6 +48,12 @@ python3Packages.buildPythonPackage rec {
   pname = "os_vif";
   version = "3.5.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/os-win.nix
+++ b/packages/os-win.nix
@@ -26,6 +26,12 @@ python3Packages.buildPythonPackage rec {
   pname = "os-win";
   version = "5.9.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
     pythonRelaxDepsHook

--- a/packages/osc-placement.nix
+++ b/packages/osc-placement.nix
@@ -17,6 +17,10 @@ python3Packages.buildPythonPackage (rec {
   pname = "osc-placement";
   version = "4.5.0";
   pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
 
   nativeBuildInputs = [
     pbr

--- a/packages/oslo-cache.nix
+++ b/packages/oslo-cache.nix
@@ -26,6 +26,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.cache";
   version = "3.9.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   propagatedBuildInputs = [
     dogpile-cache
     oslo-config

--- a/packages/oslo-concurrency.nix
+++ b/packages/oslo-concurrency.nix
@@ -22,6 +22,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.concurrency";
   version = "6.0.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   postPatch = ''
     substituteInPlace oslo_concurrency/tests/unit/test_processutils.py --replace-fail "/usr/bin/env" "${coreutils}/bin/env"
     substituteInPlace oslo_concurrency/tests/unit/test_processutils.py --replace-fail "/bin/bash" "${bash}/bin/bash"

--- a/packages/oslo-config.nix
+++ b/packages/oslo-config.nix
@@ -18,6 +18,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.config";
   version = "9.7.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/oslo-context.nix
+++ b/packages/oslo-context.nix
@@ -21,6 +21,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.context";
   version = "5.7.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/oslo-db.nix
+++ b/packages/oslo-db.nix
@@ -33,6 +33,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.db";
   version = "17.0.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   propagatedBuildInputs = [
     (alembic.override { inherit sqlalchemy; })
     debtcollector

--- a/packages/oslo-db.nix
+++ b/packages/oslo-db.nix
@@ -21,7 +21,7 @@ let
     hacking
     psycopg2
     pymysql
-    python-subunit
+    subunit
     stestr
     stevedore
     testresources
@@ -59,7 +59,7 @@ python3Packages.buildPythonPackage rec {
     pre-commit
     psycopg2
     pymysql
-    python-subunit
+    subunit
     testresources
     testscenarios
     testtools

--- a/packages/oslo-i18n.nix
+++ b/packages/oslo-i18n.nix
@@ -10,6 +10,10 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.i18n";
   version = "6.5.0";
   pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
   nativeBuildInputs = [
     pbr
     setuptools

--- a/packages/oslo-limit.nix
+++ b/packages/oslo-limit.nix
@@ -20,6 +20,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.limit";
   version = "2.6.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   propagatedBuildInputs = [
     keystoneauth1
     openstacksdk

--- a/packages/oslo-log.nix
+++ b/packages/oslo-log.nix
@@ -54,6 +54,10 @@ python3Packages.buildPythonPackage rec {
     testtools
   ];
 
+  patches = [
+    ./patches/oslo-log-pipe-mutex-context-manager.patch
+  ];
+
   checkPhase = ''
     stestr run
   '';

--- a/packages/oslo-log.nix
+++ b/packages/oslo-log.nix
@@ -23,6 +23,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.log";
   version = "6.2.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
     python-dateutil

--- a/packages/oslo-messaging.nix
+++ b/packages/oslo-messaging.nix
@@ -38,6 +38,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.messaging";
   version = "15.0.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/oslo-metrics.nix
+++ b/packages/oslo-metrics.nix
@@ -22,6 +22,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.metrics";
   version = "0.10.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/oslo-middleware.nix
+++ b/packages/oslo-middleware.nix
@@ -27,6 +27,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.middleware";
   version = "6.3.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/oslo-policy.nix
+++ b/packages/oslo-policy.nix
@@ -23,6 +23,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.policy";
   version = "4.4.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   propagatedBuildInputs = [
     oslo-config
     oslo-context

--- a/packages/oslo-privsep.nix
+++ b/packages/oslo-privsep.nix
@@ -23,6 +23,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.privsep";
   version = "3.5.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   propagatedBuildInputs = [
     cffi
     eventlet

--- a/packages/oslo-reports.nix
+++ b/packages/oslo-reports.nix
@@ -21,6 +21,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.reports";
   version = "3.5.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/oslo-rootwrap.nix
+++ b/packages/oslo-rootwrap.nix
@@ -32,6 +32,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.rootwrap";
   version = "7.4.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   postPatch = ''
     substituteInPlace ./oslo_rootwrap/tests/test_functional.py --replace-fail "/bin/cat" "${coreutils}/bin/cat"
     substituteInPlace ./oslo_rootwrap/tests/test_functional.py --replace-fail "/bin/echo" "${coreutils}/bin/echo"

--- a/packages/oslo-serialization.nix
+++ b/packages/oslo-serialization.nix
@@ -19,6 +19,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.serialization";
   version = "5.6.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/oslo-service.nix
+++ b/packages/oslo-service.nix
@@ -31,6 +31,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.service";
   version = "3.6.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
     procps

--- a/packages/oslo-upgradecheck.nix
+++ b/packages/oslo-upgradecheck.nix
@@ -20,6 +20,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.upgradecheck";
   version = "2.4.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   propagatedBuildInputs = [
     oslo-config
     oslo-i18n

--- a/packages/oslo-utils.nix
+++ b/packages/oslo-utils.nix
@@ -30,6 +30,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.utils";
   version = "7.4.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
     qemu

--- a/packages/oslo-versionedobjects.nix
+++ b/packages/oslo-versionedobjects.nix
@@ -27,6 +27,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.versionedobjects";
   version = "3.5.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   propagatedBuildInputs = [
     iso8601
     netaddr

--- a/packages/oslo-vmware.nix
+++ b/packages/oslo-vmware.nix
@@ -30,6 +30,12 @@ python3Packages.buildPythonPackage rec {
   pname = "oslo.vmware";
   version = "4.5.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/oslotest.nix
+++ b/packages/oslotest.nix
@@ -20,6 +20,10 @@ python3Packages.buildPythonPackage rec {
   version = "5.0.0";
 
   pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
 
   nativeCheckInputs = [
     stestr

--- a/packages/oslotest.nix
+++ b/packages/oslotest.nix
@@ -19,6 +19,8 @@ python3Packages.buildPythonPackage rec {
   pname = "oslotest";
   version = "5.0.0";
 
+  pyproject = true;
+
   nativeCheckInputs = [
     stestr
   ];

--- a/packages/oslotest.nix
+++ b/packages/oslotest.nix
@@ -9,7 +9,7 @@ let
     coverage
     fixtures
     hacking
-    python-subunit
+    subunit
     stestr
     testtools
     ;
@@ -27,7 +27,7 @@ python3Packages.buildPythonPackage rec {
 
   propagatedBuildInputs = [
     fixtures
-    python-subunit
+    subunit
     testtools
   ];
 

--- a/packages/osprofiler.nix
+++ b/packages/osprofiler.nix
@@ -32,6 +32,12 @@ python3Packages.buildPythonPackage rec {
   pname = "osprofiler";
   version = "4.2.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   propagatedBuildInputs = [
     netaddr
     oslo-concurrency

--- a/packages/ovs.nix
+++ b/packages/ovs.nix
@@ -21,6 +21,8 @@ python3Packages.buildPythonPackage rec {
   pname = "ovs";
   version = "3.4.1";
 
+  pyproject = true;
+
   nativeBuildInputs = [
     openvswitch
     setuptools

--- a/packages/ovsdbapp.nix
+++ b/packages/ovsdbapp.nix
@@ -22,6 +22,12 @@ python3Packages.buildPythonPackage rec {
   pname = "ovsdbapp";
   version = "2.9.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
     pythonRelaxDepsHook

--- a/packages/ovsdbapp.nix
+++ b/packages/ovsdbapp.nix
@@ -12,7 +12,7 @@ let
     netaddr
     pbr
     pythonRelaxDepsHook
-    python-subunit
+    subunit
     stestr
     testscenarios
     testtools
@@ -43,7 +43,7 @@ python3Packages.buildPythonPackage rec {
     coverage
     isort
     oslotest
-    python-subunit
+    subunit
     testscenarios
     testtools
   ];

--- a/packages/patches/oslo-log-pipe-mutex-context-manager.patch
+++ b/packages/patches/oslo-log-pipe-mutex-context-manager.patch
@@ -1,0 +1,18 @@
+diff --git a/oslo_log/pipe_mutex.py b/oslo_log/pipe_mutex.py
+index 08a1fe3..3aa4832 100644
+--- a/oslo_log/pipe_mutex.py
++++ b/oslo_log/pipe_mutex.py
+@@ -136,6 +136,13 @@ class PipeMutex:
+         # do, so nobody does it and that's okay.
+         self.close()
+ 
++    def __enter__(self):
++        self.acquire()
++        return self
++
++    def __exit__(self, exc_type, exc_value, traceback):
++        self.release()
++
+ 
+ def pipe_createLock(self):
+     """Replacement for logging.Handler.createLock method."""

--- a/packages/pre-commit.nix
+++ b/packages/pre-commit.nix
@@ -21,12 +21,16 @@ let
     pytest-env
     pyyaml
     re-assert
+    setuptools
     virtualenv
     ;
 in
 python3Packages.buildPythonPackage rec {
   pname = "pre_commit";
   version = "4.0.1";
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   nativeBuildInputs = [
     R
@@ -81,9 +85,21 @@ python3Packages.buildPythonPackage rec {
     "test_health_check_after_downgrade"
     "test_health_check_healthy"
     "test_health_check_without_version"
+    "test_healthy_default_creator"
+    "test_healthy_venv_creator"
+    "test_language_versioned_python_hook"
     "test_lots_of_files"
     "test_r_hook"
     "test_r_inline"
+    "test_python_hook_weird_setup_cfg"
+    "test_simple_python_hook"
+    "test_simple_python_hook_default_version"
+    "test_unhealthy_old_virtualenv"
+    "test_unhealthy_python_goes_missing"
+    "test_unhealthy_system_version_changes"
+    "test_unhealthy_then_replaced"
+    "test_unhealthy_unexpected_pyvenv"
+    "test_unhealthy_with_version_change"
   ];
 
   # We need to fetch the sources directly from GitHub here, because the

--- a/packages/pycadf.nix
+++ b/packages/pycadf.nix
@@ -21,6 +21,12 @@ python3Packages.buildPythonPackage rec {
   pname = "pycadf";
   version = "4.0.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
     stestr

--- a/packages/pycadf.nix
+++ b/packages/pycadf.nix
@@ -11,7 +11,7 @@ let
     flake8-import-order
     hacking
     pbr
-    python-subunit
+    subunit
     pytz
     stestr
     testtools
@@ -37,7 +37,7 @@ python3Packages.buildPythonPackage rec {
     fixtures
     flake8-import-order
     hacking
-    python-subunit
+    subunit
     testtools
   ];
 

--- a/packages/python-barbicanclient.nix
+++ b/packages/python-barbicanclient.nix
@@ -26,6 +26,12 @@ python3Packages.buildPythonPackage rec {
   pname = "python-barbicanclient";
   version = "7.0.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
     stestr

--- a/packages/python-binary-memcached.nix
+++ b/packages/python-binary-memcached.nix
@@ -17,6 +17,9 @@ python3Packages.buildPythonPackage rec {
   pname = "python_binary_memcached";
   version = "0.31.3";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   propagatedBuildInputs = [
     six
     uhashring

--- a/packages/python-cinderclient.nix
+++ b/packages/python-cinderclient.nix
@@ -64,7 +64,7 @@ python3Packages.buildPythonPackage rec {
 
   checkPhase = ''
     runHook preCheck
-    stestr run
+    stestr run --exclude-regex test_load_versioned_actions_with_help
     runHook postCheck
   '';
 

--- a/packages/python-designateclient.nix
+++ b/packages/python-designateclient.nix
@@ -28,6 +28,8 @@ python3Packages.buildPythonPackage rec {
   pname = "python-designateclient";
   version = "6.1.0";
 
+  pyproject = true;
+
   propagatedBuildInputs = [
     cliff
     debtcollector

--- a/packages/python-designateclient.nix
+++ b/packages/python-designateclient.nix
@@ -30,6 +30,11 @@ python3Packages.buildPythonPackage rec {
 
   pyproject = true;
 
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   propagatedBuildInputs = [
     cliff
     debtcollector

--- a/packages/python-designateclient.nix
+++ b/packages/python-designateclient.nix
@@ -16,7 +16,7 @@ let
     debtcollector
     hacking
     jsonschema
-    python-subunit
+    subunit
     requests
     requests-mock
     stestr
@@ -49,7 +49,7 @@ python3Packages.buildPythonPackage rec {
     hacking
     oslo-config
     oslotest
-    python-subunit
+    subunit
     reno
     requests-mock
     tempest

--- a/packages/python-glanceclient.nix
+++ b/packages/python-glanceclient.nix
@@ -1,0 +1,104 @@
+{
+  fetchPypi,
+  keystoneauth1,
+  lib,
+  openstacksdk,
+  oslo-i18n,
+  oslo-utils,
+  python3Packages,
+  writeText,
+}:
+let
+  inherit (python3Packages)
+    ddt
+    pbr
+    prettytable
+    pyopenssl
+    requests
+    requests-mock
+    stestr
+    testscenarios
+    warlock
+    wrapt
+    ;
+
+  disabledTests = [
+    # Skip tests which require networking.
+    "test_http_chunked_response"
+    "test_v1_download_has_no_stray_output_to_stdout"
+    "test_v2_requests_valid_cert_verification"
+    "test_download_has_no_stray_output_to_stdout"
+    "test_v1_requests_cert_verification_no_compression"
+    "test_v1_requests_cert_verification"
+    "test_v2_download_has_no_stray_output_to_stdout"
+    "test_v2_requests_bad_ca"
+    "test_v2_requests_bad_cert"
+    "test_v2_requests_cert_verification_no_compression"
+    "test_v2_requests_cert_verification"
+    "test_v2_requests_valid_cert_no_key"
+    "test_v2_requests_valid_cert_verification_no_compression"
+    "test_log_request_id_once"
+    # asserts exact amount of mock calls
+    "test_cache_schemas_gets_when_forced"
+    "test_cache_schemas_gets_when_not_exists"
+    # binary dosn't exist in nixos: /bin/echo
+    "test_image_update_data_is_read_from_pipe"
+  ];
+in
+python3Packages.buildPythonPackage rec {
+  pname = "python-glanceclient";
+  version = "4.7.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-wZRS7xLaPEhLadIqiIznp0kQvbh4O76RJIxg76U3iBA=";
+  };
+
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
+  propagatedBuildInputs = [
+    keystoneauth1
+    oslo-i18n
+    oslo-utils
+    pbr
+    prettytable
+    pyopenssl
+    requests
+    warlock
+    wrapt
+  ];
+
+  nativeCheckInputs = [
+    ddt
+    openstacksdk
+    requests-mock
+    stestr
+    testscenarios
+  ];
+
+  checkInputs = [
+    ddt
+    keystoneauth1
+    oslo-i18n
+    oslo-utils
+    pbr
+    prettytable
+    pyopenssl
+    requests
+    requests-mock
+    testscenarios
+    warlock
+    wrapt
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    stestr run -e ${writeText "disabled-tests" (lib.concatStringsSep "\n" disabledTests)}
+    runHook postCheck
+  '';
+
+}

--- a/packages/python-keystoneclient.nix
+++ b/packages/python-keystoneclient.nix
@@ -36,6 +36,12 @@ python3Packages.buildPythonPackage rec {
   pname = "python-keystoneclient";
   version = "5.5.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     openssl
     pbr

--- a/packages/python-neutronclient.nix
+++ b/packages/python-neutronclient.nix
@@ -27,7 +27,7 @@ let
     pbr
     python-dateutil
     python-openstackclient
-    python-subunit
+    subunit
     requests
     requests-mock
     stestr
@@ -73,7 +73,7 @@ python3Packages.buildPythonPackage rec {
     oslotest
     osprofiler
     python-openstackclient
-    python-subunit
+    subunit
     requests-mock
     testtools
   ];

--- a/packages/python-neutronclient.nix
+++ b/packages/python-neutronclient.nix
@@ -38,6 +38,12 @@ python3Packages.buildPythonPackage rec {
   pname = "python-neutronclient";
   version = "11.3.1";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     pbr
   ];

--- a/packages/python-novaclient.nix
+++ b/packages/python-novaclient.nix
@@ -1,0 +1,74 @@
+{
+  python3Packages,
+  keystoneauth1,
+  oslo-i18n,
+  oslo-serialization,
+  oslo-utils,
+  openssl,
+}:
+let
+  inherit (python3Packages)
+    ddt
+    iso8601
+    pbr
+    prettytable
+    pythonOlder
+    requests-mock
+    stestr
+    stevedore
+    testscenarios
+    ;
+in
+python3Packages.buildPythonPackage rec {
+  pname = "python-novaclient";
+  version = "18.7.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    hash = "sha256-lMrQ8PTBYc7VKl7NhdE0/Wc7mX2nGUoDHAymk0Q0Cw0=";
+  };
+
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
+  nativeBuildInputs = [
+    pbr
+  ];
+
+  dependencies = [
+    iso8601
+    keystoneauth1
+    oslo-i18n
+    oslo-serialization
+    oslo-utils
+    pbr
+    prettytable
+    stevedore
+  ];
+
+  nativeCheckInputs = [
+    ddt
+    openssl
+    requests-mock
+    stestr
+    testscenarios
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    stestr run -e <(echo "
+    novaclient.tests.unit.test_shell.ParserTest.test_ambiguous_option
+    novaclient.tests.unit.test_shell.ParserTest.test_not_really_ambiguous_option
+    novaclient.tests.unit.test_shell.ShellTest.test_osprofiler
+    novaclient.tests.unit.test_shell.ShellTestKeystoneV3.test_osprofiler
+    ")
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [ "novaclient" ];
+}

--- a/packages/python-openstackclient.nix
+++ b/packages/python-openstackclient.nix
@@ -1,0 +1,71 @@
+{
+  openstacksdk,
+  osc-lib,
+  oslo-i18n,
+  python-cinderclient,
+  python-keystoneclient,
+  python3Packages,
+}:
+let
+  inherit (python3Packages)
+    ddt
+    cliff
+    cryptography
+    iso8601
+    pbr
+    pythonOlder
+    requests
+    requests-mock
+    stestr
+    stevedore
+    ;
+in
+python3Packages.buildPythonPackage rec {
+  pname = "python_openstackclient";
+  version = "8.0.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    hash = "sha256-W3peBok/gztdKW0BnFDULHNo43dI7mvo6bFWVbmZQk4=";
+  };
+
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
+  nativeBuildInputs = [
+    pbr
+  ];
+
+  dependencies = [
+    cliff
+    cryptography
+    iso8601
+    openstacksdk
+    osc-lib
+    oslo-i18n
+    pbr
+    python-cinderclient
+    python-keystoneclient
+    requests
+    stevedore
+  ];
+
+  checkInputs = [
+    ddt
+    requests-mock
+    stestr
+  ];
+
+  nativeCheckInputs = [
+    stestr
+  ];
+
+  checkPhase = ''
+    stestr run --exclude-regex test_endpoint_list_project_with_project_domain
+  '';
+}

--- a/packages/python-swiftclient.nix
+++ b/packages/python-swiftclient.nix
@@ -19,6 +19,10 @@ python3Packages.buildPythonPackage rec {
   pname = "python-swiftclient";
   version = "4.6.0";
   pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
 
   nativeBuildInputs = [
     pbr

--- a/packages/rcssmin.nix
+++ b/packages/rcssmin.nix
@@ -1,0 +1,26 @@
+{
+  fetchPypi,
+  python3Packages,
+}:
+let
+  inherit (python3Packages)
+    setuptools
+    pip
+    ;
+in
+python3Packages.buildPythonPackage rec {
+  pname = "rcssmin";
+  version = "1.1.2";
+
+  pyproject = true;
+
+  nativeBuildInputs = [
+    setuptools
+    pip
+  ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-vHXrdb1tNFwMUf2A/Eh93W+f1AndeGGz/pje6FAY4ek=";
+  };
+}

--- a/packages/reno.nix
+++ b/packages/reno.nix
@@ -11,7 +11,7 @@ let
     openstackdocstheme
     packaging
     pbr
-    python-subunit
+    subunit
     pyyaml
     stestr
     testscenarios
@@ -41,7 +41,7 @@ python3Packages.buildPythonPackage rec {
   checkInputs = [
     coverage
     openstackdocstheme
-    python-subunit
+    subunit
     testscenarios
     testtools
   ];

--- a/packages/reno.nix
+++ b/packages/reno.nix
@@ -22,6 +22,12 @@ python3Packages.buildPythonPackage rec {
   pname = "reno";
   version = "4.1.0";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
+
   nativeBuildInputs = [
     git
     gnupg

--- a/packages/rjsmin.nix
+++ b/packages/rjsmin.nix
@@ -1,0 +1,26 @@
+{
+  fetchPypi,
+  python3Packages,
+}:
+let
+  inherit (python3Packages)
+    setuptools
+    pip
+    ;
+in
+python3Packages.buildPythonPackage rec {
+  pname = "rjsmin";
+  version = "1.2.2";
+
+  pyproject = true;
+
+  nativeBuildInputs = [
+    setuptools
+    pip
+  ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-jBvNghFD/s8jJCAStV4TYQhAqDnNRns1jxY1kBDWLa4=";
+  };
+}

--- a/packages/sphinxcontrib-svg2pdfconverter.nix
+++ b/packages/sphinxcontrib-svg2pdfconverter.nix
@@ -9,6 +9,9 @@ python3Packages.buildPythonPackage rec {
   pname = "sphinxcontrib_svg2pdfconverter";
   version = "1.2.3";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   nativeBuildInputs = [
     sphinx
   ];

--- a/packages/sqlalchemy.nix
+++ b/packages/sqlalchemy.nix
@@ -11,6 +11,12 @@ python3Packages.buildPythonPackage rec {
   pname = "sqlalchemy";
   version = "2.0.34";
 
+  pyproject = true;
+  build-system = [
+    python3Packages.cython
+    python3Packages.setuptools
+  ];
+
   propagatedBuildInputs = [
     typing-extensions
   ];

--- a/packages/suds-community.nix
+++ b/packages/suds-community.nix
@@ -11,6 +11,9 @@ python3Packages.buildPythonPackage rec {
   pname = "suds_community";
   version = "1.2.0";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   checkInputs = [
     pytest
   ];

--- a/packages/taskflow.nix
+++ b/packages/taskflow.nix
@@ -39,6 +39,10 @@ python3Packages.buildPythonPackage rec {
   pname = "taskflow";
   version = "5.10.0";
   pyproject = true;
+  build-system = [
+    python3Packages.pbr
+    python3Packages.setuptools
+  ];
 
   nativeBuildInputs = [
     pbr

--- a/packages/tooz.nix
+++ b/packages/tooz.nix
@@ -21,7 +21,7 @@ let
     pymysql
     stestr
     stevedore
-    sysv_ipc
+    sysv-ipc
     tenacity
     testtools
     voluptuous
@@ -39,6 +39,8 @@ in
 python3Packages.buildPythonPackage rec {
   pname = "tooz";
   version = "6.3.0";
+
+  pyproject = true;
 
   propagatedBuildInputs = [
     fasteners
@@ -59,7 +61,7 @@ python3Packages.buildPythonPackage rec {
     pifpaf
     pymemcache
     pymysql
-    sysv_ipc
+    sysv-ipc
     testtools
     zake
   ];

--- a/packages/xstatic-angular-bootstrap.nix
+++ b/packages/xstatic-angular-bootstrap.nix
@@ -6,6 +6,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-Angular-Bootstrap";
   version = "2.5.0.0";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-vmBobJopx0zurdeHlpwry8458Vsw2qSUlXSuymAvnzU=";

--- a/packages/xstatic-angular-fileupload.nix
+++ b/packages/xstatic-angular-fileupload.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-Angular-FileUpload";
   version = "12.2.13.0";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-+PQxrH+zewGgEIEfuK6X8ODLEcu9BOScWGfqf3T62lY=";

--- a/packages/xstatic-angular-gettext.nix
+++ b/packages/xstatic-angular-gettext.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-Angular-Gettext";
   version = "2.4.1.0";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-iDGSySc7LRuNxp5gWEXw06JnaYlV5V3N4OOk3v6uOFs=";

--- a/packages/xstatic-angular-lrdragndrop.nix
+++ b/packages/xstatic-angular-lrdragndrop.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-Angular-lrdragndrop";
   version = "1.0.2.6";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-j2cJXpbA1K2Vz2k4xltAnODmEDbPpEo80HRHlLs7BQE=";

--- a/packages/xstatic-angular-schema-form.nix
+++ b/packages/xstatic-angular-schema-form.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-Angular-Schema-Form";
   version = "0.8.13.0";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-fAhjSQF1Emf+JtJm/AJ89u0uX0Imlphc7HUFlLP04wA=";

--- a/packages/xstatic-angular.nix
+++ b/packages/xstatic-angular.nix
@@ -6,6 +6,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-Angular";
   version = "1.8.2.2";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-TIFq1aH5krHWPNKXXjwSYvyghnL1mG4YOKu2TtdcgyM=";

--- a/packages/xstatic-bootstrap-datepicker.nix
+++ b/packages/xstatic-bootstrap-datepicker.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-Bootstrap-Datepicker";
   version = "1.4.0.0";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-3zOt2fXnhfqISsSxgmAa9qrJ4e7vfP5i27ywZU0PLW4=";

--- a/packages/xstatic-bootstrap-scss.nix
+++ b/packages/xstatic-bootstrap-scss.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-Bootstrap-SCSS";
   version = "3.4.1.0";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-XLVvAJDLZInWQ3MN5Xxo2KZxTyuf5Sasibto9dd9/hA=";

--- a/packages/xstatic-bootswatch.nix
+++ b/packages/xstatic-bootswatch.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-bootswatch";
   version = "3.3.7.0";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-k+5YY8HsByEv4SrhN6EHCLQQJyA5HUYPBh3T9EG6O24=";

--- a/packages/xstatic-d3.nix
+++ b/packages/xstatic-d3.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-D3";
   version = "3.5.17.0";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-F26T7ucZLgf8VDNN2xprZPz8jN5quyP2VyeFa7ndGCk=";

--- a/packages/xstatic-font-awesome.nix
+++ b/packages/xstatic-font-awesome.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-Font-Awesome";
   version = "4.7.0.0";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-4B+0gMqqfHlj3LMyikcA5jG+9gcNsOi2hYFtIg5oX2w=";

--- a/packages/xstatic-hogan.nix
+++ b/packages/xstatic-hogan.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-Hogan";
   version = "2.0.0.3";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-J6khlj5HCrutoVsthdGYgzeVqurV/XMzm8KIPP3bVhk=";

--- a/packages/xstatic-jasmine.nix
+++ b/packages/xstatic-jasmine.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-Jasmine";
   version = "2.4.1.2";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-v5Ib5CPCVKXOvCFWp/1m2CEM79JR/C+lH3kqFTv56Cs=";

--- a/packages/xstatic-jquery-migrate.nix
+++ b/packages/xstatic-jquery-migrate.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-JQuery-Migrate";
   version = "3.3.2.1";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-mG+Xmg4toKRTQaAzaRgRFH/fbqqXpwa3qz2edxHOrW4=";

--- a/packages/xstatic-jquery-quicksearch.nix
+++ b/packages/xstatic-jquery-quicksearch.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-JQuery.quicksearch";
   version = "2.0.3.2";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-84dg/pO1BPKFXvJem/kd9lyKZgFnQWXkaF+yF7thb9E=";

--- a/packages/xstatic-jquery-tablesorter.nix
+++ b/packages/xstatic-jquery-tablesorter.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-JQuery.TableSorter";
   version = "2.14.5.2";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-vdhHygzeQBT9IRNPmeWame9IgYXHRegmRpEdL53j12I=";

--- a/packages/xstatic-jsencrypt.nix
+++ b/packages/xstatic-jsencrypt.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-JSEncrypt";
   version = "2.3.1.1";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-oneRKk9w0dL1jI2UuZLSROafz4UaLL7V2Dy0/EIqcvI=";

--- a/packages/xstatic-mdi.nix
+++ b/packages/xstatic-mdi.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-mdi";
   version = "1.6.50.2";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-vhAFr3pZOws6NJqtsF5BYOpliUJIpHskbGZYNF4vEME=";

--- a/packages/xstatic-objectpath.nix
+++ b/packages/xstatic-objectpath.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-objectpath";
   version = "1.2.1.0";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
 

--- a/packages/xstatic-rickshaw.nix
+++ b/packages/xstatic-rickshaw.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-Rickshaw";
   version = "1.5.1.0";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-zyeNS9TpdN3PcXDSC7twbMNPk89hZY8vaPMTg3QXhWQ=";

--- a/packages/xstatic-roboto-fontface.nix
+++ b/packages/xstatic-roboto-fontface.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-roboto-fontface";
   version = "0.5.0.0";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-bSct9Y4g7sOhW8onkWPzhhTHB04v7LU3pYsp0QnoP2I=";

--- a/packages/xstatic-smart-table.nix
+++ b/packages/xstatic-smart-table.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-smart-table";
   version = "1.4.13.2";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-8vpe03wpUyU955xhw0b6bDxPOHMSldIkBVLBQpjbawo=";

--- a/packages/xstatic-spin.nix
+++ b/packages/xstatic-spin.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-Spin";
   version = "1.2.5.3";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-BuiJzzMY8IznTviItF2fHgkBe7jm1RmimcEKnmtUJkI=";

--- a/packages/xstatic-term-js.nix
+++ b/packages/xstatic-term-js.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-term.js";
   version = "0.0.7.0";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-tfOractjg5HwQlSROhGyqrCOLVHFuBu2pWTFptRCvTE=";

--- a/packages/xstatic-tv4.nix
+++ b/packages/xstatic-tv4.nix
@@ -3,6 +3,9 @@ python3Packages.buildPythonPackage rec {
   pname = "XStatic-tv4";
   version = "1.2.7.0";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "sha256-m0xXJE6RQSbN2l2LwkaYGJ1zgAIDyFsfyUWgjiXHxxM=";

--- a/tests/openstack-default-setup.nix
+++ b/tests/openstack-default-setup.nix
@@ -135,7 +135,7 @@ pkgs.testers.nixosTest {
 
       # Ping the OpenStack VM from the controller host. We use the network
       # namespace dedicated for the VM to ping it.
-      assert retry_until_succeed(controllerVM, f"ip netns exec {net_ns} ping -c 1 {vm_ip}", 30)
+      assert retry_until_succeed(controllerVM, f"ip netns exec {net_ns} ping -c 1 {vm_ip}", 120)
 
       # create volume with 4GB
       controllerVM.execute("openstack volume create --size 4 test_vol")
@@ -155,7 +155,7 @@ pkgs.testers.nixosTest {
       print(f"openstack volume show test_vol: {output}")
 
       # wait until volume is attached
-      assert retry_until_succeed(controllerVM, "openstack volume show test_vol -f value -c status | grep 'in-use'", 40)
+      assert retry_until_succeed(controllerVM, "openstack volume show test_vol -f value -c status | grep 'in-use'", 120)
 
       # add ssh host key to known_hosts
       retry_until_succeed(controllerVM, f"ip netns exec {net_ns} ssh-keyscan {vm_ip} > ~/.ssh/known_hosts", 60)

--- a/tests/openstack-default-setup.nix
+++ b/tests/openstack-default-setup.nix
@@ -2,7 +2,7 @@
   pkgs,
   nixosModules,
 }:
-pkgs.nixosTest {
+pkgs.testers.nixosTest {
   name = "OpenStack default setup test";
 
   nodes.controllerVM =

--- a/tests/openstack-live-migration.nix
+++ b/tests/openstack-live-migration.nix
@@ -274,7 +274,7 @@ pkgs.testers.nixosTest {
       net_ns = wait_for_network_namespace()
       assert net_ns != ""
 
-      assert retry_until_succeed(controllerVM, f"ip netns exec {net_ns} ping -c 1 {vm_ip}", 30)
+      assert retry_until_succeed(controllerVM, f"ip netns exec {net_ns} ping -c 1 {vm_ip}", 120)
 
       print(f"Start migration from src: {host} to destination {dst_host}")
       controllerVM.succeed(f"openstack server migrate --live-migration --host {dst_host} test_vm")
@@ -284,6 +284,6 @@ pkgs.testers.nixosTest {
       vm_state = json.loads(controllerVM.succeed("openstack server show test_vm -f json"))
       assert vm_state["OS-EXT-SRV-ATTR:host"] == dst_host
 
-      assert retry_until_succeed(controllerVM, f"ip netns exec {net_ns} ping -c 1 {vm_ip}", 30)
+      assert retry_until_succeed(controllerVM, f"ip netns exec {net_ns} ping -c 1 {vm_ip}", 120)
     '';
 }

--- a/tests/openstack-live-migration.nix
+++ b/tests/openstack-live-migration.nix
@@ -112,7 +112,7 @@ let
         '';
     };
 in
-pkgs.nixosTest {
+pkgs.testers.nixosTest {
   name = "OpenStack live migration test";
 
   nodes.controllerVM =


### PR DESCRIPTION
A lot of changes in the python package builds were required. Additionally, some patches to certain libs that had breaking changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved build/packaging compatibility across many Python components by enabling pyproject/PEP 517 workflows and declaring standardized build backends.
  * Enhanced OpenStack controller packaging wiring by ensuring the Python OpenStack client tooling is included where needed.

* **Bug Fixes**
  * Improved OpenStack integration test reliability by increasing retry timeouts for VM ping and storage state checks.

* **Documentation**
  * Refreshed generated configuration comment wording and updated testing snippet usage.

* **Chores**
  * Updated the underlying Nix package set and tightened typo-checker ignores; minor service/option formatting cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->