### PR TITLE
Setup cachix binary cache

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: cachix/install-nix-action@v31
       - name: Nix Flake Checks
         run: nix flake check --all-systems
-  nixos-tests:
+  nixos-basic-test:
     runs-on: large_runner_16core_64gb
     steps:
       - uses: actions/checkout@v6
@@ -28,6 +28,22 @@ jobs:
       - name: Basic setup
         run: |
           nix run .#tests.x86_64-linux.openstack-default-setup.driver
+  nixos-live-migration-test:
+    runs-on: large_runner_16core_64gb
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v17
+        with:
+          name: openstack-nix
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - name: Build
+        run: |
+          set -euxo pipefail
+          nix build --show-trace \
+            --option max-jobs 1 \
+            --option cores 4 \
+            .#tests.x86_64-linux.openstack-live-migration.driver
       - name: Live migration
         run: |
           nix run .#tests.x86_64-linux.openstack-live-migration.driver

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,5 +1,7 @@
 name: QA
 on: [ pull_request ]
+permissions:
+  contents: read
 jobs:
   flake-check:
     name: Nix Flake Checks
@@ -32,6 +34,8 @@ jobs:
     runs-on: large_runner_16core_64gb
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: cachix/install-nix-action@v31
       - uses: cachix/cachix-action@v17
         with:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v17
+        with:
+          name: openstack-nix
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Build
         run: |
           set -euxo pipefail


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated testing by enabling an OpenStack Nix build cache to speed up CI runs.
  * Kept existing flake checks unchanged.
  * Added a new NixOS live migration test job that installs Nix, uses the same cache setup, and runs the live-migration test driver.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->