### PR TITLE
fix openstack-placement with nixpkg update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780902259,
-        "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
+        "lastModified": 1785386831,
+        "narHash": "sha256-sPS3CaXH8RAT3FZRuy4VcV47iuYIWMMfa0GbyJKC3o4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
+        "rev": "21ea275a7c46aef9d4d6ddc962e6d562e9d94183",
         "type": "github"
       },
       "original": {

--- a/packages/openstack-placement.nix
+++ b/packages/openstack-placement.nix
@@ -68,7 +68,6 @@ python3Packages.buildPythonPackage (rec {
   ];
 
   checkPhase = ''
-    substituteInPlace placement/tests/unit/cmd/test_manage.py --replace-fail "choose from 'db'" "choose from db"
     stestr run
   '';
 


### PR DESCRIPTION
python workaround must be removed after nixpkg
update from 2026-06-08 -> 2026-07-30


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified package test execution by running tests directly for more efficient test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->